### PR TITLE
[PROPOSAL] Introduce SQLite to handle counters

### DIFF
--- a/src/Classes/CounterHandler
+++ b/src/Classes/CounterHandler
@@ -1,0 +1,48 @@
+<?php
+
+namespace SleekDB\Classes;
+
+use SQLite3;
+
+class CounterHandler
+{
+  protected $db;
+
+  /**
+   * @param string $dataPath
+   * @param string $counterPath
+   */
+  public function __construct(string $dataPath, string $counterPath)
+  {
+    $rebuild = !is_file($counterPath);
+    $this->db = new SQLite3($counterPath);
+    $this->db->query('PRAGMA synchronous = OFF');
+    $this->db->query('PRAGMA journal_mode = WAL');
+    $this->db->query('PRAGMA journal_size_limit = 6144000');
+    $this->db->query('PRAGMA ignore_check_constraints = ON');
+    $this->db->query('PRAGMA cache_size = 128');
+    $this->db->query('PRAGMA temp_store = 2');
+    if ($rebuild) {
+      $this->db->query("CREATE TABLE IF NOT EXISTS counter (nil INT)");
+      $lastID = (int)str_replace('.json', '', IoHelper::getLastFilename($dataPath));
+      if ($lastID > 0) $this->db->query("INSERT INTO counter (rowid, nil) VALUES ({$lastID}, null)");
+    }
+  }
+
+  /**
+   * @return integer
+   */
+  public function increaseCounterAndGetNextId(): int
+  {
+    $this->db->query("INSERT INTO counter VALUES (null)");
+    return (int)$this->db->lastInsertRowID();
+  }
+
+  /**
+   * @return integer
+   */
+  public function getLastInsertedId(): int
+  {
+    return (int)$this->db->querySingle("SELECT seq FROM sqlite_sequence WHERE name = 'counter'");
+  }
+}


### PR DESCRIPTION
_(This PR is not ready for merge, it mostly serves as demonstration for the case in the hopes of sparking a conversation)_

When conducting massive insert operations, the main performance bottleneck appears to be the `_cnt.sdb` file holding the counting, i.e. the last inserted ID of the collection, due to I/O concurrency.

By leveraging SQLite exclusively for the purpose of acting as the counter for the collection, performances can improve by 40% to 50% depending on the number of records and method used (either `insert` or `insertMany`). The SQLite instance is optimized for fast INSERTs, adopting WAL and turning off synchronous ops. It also features an automatic repair of the SQLite file in case of accidental or intentional delete.

Other changes introduced:
- reduced the number of calls to checkWrite and checkRead: they are performed only once, at `Store::__construct` time; less secure, but the chances of permissions changing mid-execution are seldom to none;
- removed write lock if the file being written is new;
- fixed PHP 8.4.x deprecation on implicitly nullable parameters;

## Benchmark

- BEFORE create store + insertMany
10.000 records = 892ms
100.000 records = 8.795ms

- AFTER create store + insertMany
10.000 records = 459ms (-49%)
100.000 records = 4.375ms (-50%)

- BEFORE create store + insert
10.000 records = 1.155ms
100.000 records = 11.211ms

- AFTER create store + insert
10.000 records = 651ms (-43%)
100.000 records = 6.731ms (-40%)